### PR TITLE
Fixed a bug that prevented codePanel_off from working for files in su…

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -27,7 +27,7 @@ under the License.
     <%= stylesheet_link_tag :screen, media: :screen %>
     <%= stylesheet_link_tag :print, media: :print %>
     <% if codePanel_off %>
-      <link href="stylesheets/inlinecode_screen.css" rel="stylesheet" type="text/css" media="screen" />
+      <%= stylesheet_link_tag :inlinecode_screen, media: :screen %>
       <% language_tabs = false %>
     <% end %>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>


### PR DESCRIPTION
Fixed a bug that prevented codePanel_off from working for files in subdirectories.

Replaced hardcoded <link> tag with <%= stylesheet_link_tag %> directive that automatically uses the correct path to find stylesheets, even for files in subdirectories. 
